### PR TITLE
Revert "fix: enable compile-builder"

### DIFF
--- a/.github/workflows/slsa-goreleaser.yml
+++ b/.github/workflows/slsa-goreleaser.yml
@@ -42,4 +42,3 @@ jobs:
       go-version: 1.17
       # Optional: only needed if using ldflags.
       evaluated-envs: "COMMIT_DATE:${{needs.args.outputs.commit-date}}, COMMIT:${{needs.args.outputs.commit}}, VERSION:${{needs.args.outputs.version}}, TREE_STATE:${{needs.args.outputs.tree-state}}"
-      compile-builder: true # https://github.com/slsa-framework/slsa-github-generator/issues/942#issuecomment-1263610114


### PR DESCRIPTION
Reverts suzuki-shunsuke/test-slsa-goreleaser#7

This change may be unneeded by updating the action to https://github.com/slsa-framework/slsa-github-generator/releases/tag/v1.2.1